### PR TITLE
Allow for indata *.fits files to be compressed with gzip

### DIFF
--- a/libs/a0v_flatten.py
+++ b/libs/a0v_flatten.py
@@ -1,4 +1,4 @@
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 import numpy as np
 import scipy.ndimage as ni
 

--- a/libs/a0v_spec.py
+++ b/libs/a0v_spec.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 from scipy.interpolate import interp1d
 from libs.master_calib import get_master_calib_abspath
 

--- a/libs/apertures.py
+++ b/libs/apertures.py
@@ -200,7 +200,7 @@ class Apertures(object):
 
             msk10 = shiftx(msk1)
             if debug:
-                import astropy.io.fits as pyfits
+                import libs.fits as pyfits
                 hdu_list = pyfits.HDUList()
                 #hdu_list.append(pyfits.PrimaryHDU(data=msk1.astype("i4")))
                 hdu_list.append(pyfits.PrimaryHDU(data=np.array(msk1, dtype="i")))
@@ -229,7 +229,7 @@ class Apertures(object):
 
         SAVE_PROFILE = False
         if SAVE_PROFILE:
-            import astropy.io.fits as pyfits
+            import libs.fits as pyfits
             hl = pyfits.HDUList()
             hl.append(pyfits.PrimaryHDU())
 
@@ -317,7 +317,7 @@ class Apertures(object):
 
         SAVE_PROFILE = False
         if SAVE_PROFILE:
-            import astropy.io.fits as pyfits
+            import libs.fits as pyfits
             hl = pyfits.HDUList()
             hl.append(pyfits.PrimaryHDU())
 

--- a/libs/badpixel.py
+++ b/libs/badpixel.py
@@ -48,7 +48,7 @@ def estimate_normalization_percentile(d, lower_limit, bpix_mask,
 
 if __name__ == "__main__":
     def get_file(i):
-        import astropy.io.fits as pyfits
+        import libs.fits as pyfits
         f = pyfits.open("../20140526/SDCH_20140526_%04d.fits" % i)
         f[0].data -= np.median(f[0].data, axis=1)
         return f

--- a/libs/basic.py
+++ b/libs/basic.py
@@ -11,7 +11,7 @@ from scipy.ndimage import gaussian_filter
 from scipy.interpolate import griddata, interp2d, interp1d  
 from scipy.stats import nanmean,nanmedian,nanstd
 from H_series import H_series
-import pyfits
+import libs.fits as pyfits
 
 
 #############################################################################

--- a/libs/correct_distortion.py
+++ b/libs/correct_distortion.py
@@ -1,5 +1,5 @@
 import numpy as np
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 from scipy.interpolate import interp1d
 from numpy.polynomial import Polynomial
 

--- a/libs/cosmics.py
+++ b/libs/cosmics.py
@@ -61,7 +61,7 @@ import numpy as np
 import math
 import scipy.signal as signal
 import scipy.ndimage as ndimage
-import pyfits
+import libs.fits as pyfits
 
 
 

--- a/libs/estimate_sky.py
+++ b/libs/estimate_sky.py
@@ -1,6 +1,6 @@
 import numpy as np
 #from jj_recipe_base import get_pr
-#import astropy.io.fits as pyfits
+#import libs.fits as pyfits
 import scipy.ndimage as ni
 
 

--- a/libs/fit_gaussian.py
+++ b/libs/fit_gaussian.py
@@ -124,7 +124,7 @@ def plot_sol(ax, sol):
 
 if __name__ == "__main__":
 
-    import astropy.io.fits as pyfits
+    import libs.fits as pyfits
     f = pyfits.open("crires/CR_GCAT_061130A_lines_hitran.fits")
     d = f[1].data
 

--- a/libs/fits.py
+++ b/libs/fits.py
@@ -1,0 +1,31 @@
+import os
+from astropy.io.fits import *  # generally import * is horrid, but is marginally acceptable in this context
+from astropy.io.fits import open as fits_open_original
+
+# Purpose of this module is to provide a wrapper to astropy.io.fits which will 
+# automatically read in either FILENAME.fits *or* FILENAME.fits.gz, whichever
+# one exists on disk.
+
+# Note that astropy.io.fits already handles gzip'd files well, so the purpose of this wrapper is
+# really just to hide the *.gz suffix from the rest of the IGRINS PLP code.
+
+# TODO someday:  automatically gzip output as well
+
+# By replacing throughout igrins plp:
+#     import astropy.io.fits as pyfits
+# with
+#     import libs.fits as pyfits
+
+def open(name, **kwargs):
+    """
+    Simple wrapper to astropy.io.fits.open that receives FILENAME.fits in name, 
+    and then:
+        if FILENAME.fits.gz exists on disk, opens FILENAME.fits.gz
+    otherwise
+        proceeds with opening FILENAME.fits
+    """
+    if os.path.isfile(name + '.gz'):
+        return fits_open_original(name + '.gz', **kwargs)
+    else:
+        return fits_open_original(name, **kwargs)
+

--- a/libs/hitran.py
+++ b/libs/hitran.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 import scipy.ndimage as ni
 
 

--- a/libs/image_combine.py
+++ b/libs/image_combine.py
@@ -1,4 +1,4 @@
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 from stsci_helper import stsci_median
 
 def make_combined_image_thar(helper, band, obsids):

--- a/libs/iraf_helper.py
+++ b/libs/iraf_helper.py
@@ -1,4 +1,4 @@
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 
 default_header_str = """WCSDIM  =                    3
 CTYPE1  = 'MULTISPE'

--- a/libs/master_calib.py
+++ b/libs/master_calib.py
@@ -78,7 +78,7 @@ def json_loader(fn):
     return json.load(open(fn))
 
 def fits_loader(fn):
-    import astropy.io.fits as pyfits
+    import libs.fits as pyfits
     return pyfits.open(fn)
 
 

--- a/libs/path_info.py
+++ b/libs/path_info.py
@@ -1,7 +1,7 @@
 
 import os
 from os.path import join
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 
 def ensure_dir(d):
     if not os.path.exists(d):

--- a/libs/process_thar.py
+++ b/libs/process_thar.py
@@ -1,7 +1,7 @@
 import os
 import numpy as np
 
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 from stsci_helper import stsci_median
 
 #from products import PipelineProducts

--- a/libs/products.py
+++ b/libs/products.py
@@ -3,7 +3,7 @@ from json_helper import json_dump
 import json
 import numpy as np
 
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 #from astropy.io.fits import Card
 
 class PipelineImage(object):

--- a/libs/readmultispec.py
+++ b/libs/readmultispec.py
@@ -39,7 +39,7 @@ Apologies for any IDL-isms that remain!
 """
 
 import numpy as np
-from astropy.io import fits as pyfits
+import libs.fits as pyfits
 
 
 def nonlinearwave(nwave, specstr, verbose=False):

--- a/libs/smooth_continuum.py
+++ b/libs/smooth_continuum.py
@@ -185,7 +185,7 @@ if __name__ == "__main__":
     #for s1 in specs:
     #    plot(s1)
 
-    import astropy.io.fits as pyfits
+    import libs.fits as pyfits
     dd = pyfits.open("outdata/20140525/SDC%s_20140525_0016.spec.fits" % band)[0].data
 
     #ii = 0

--- a/libs/trace_flat.py
+++ b/libs/trace_flat.py
@@ -5,7 +5,7 @@
 import os
 import numpy as np
 
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 import scipy.ndimage as ni
 
 import badpixel as bp

--- a/libs/variance_map.py
+++ b/libs/variance_map.py
@@ -90,7 +90,7 @@ def get_variance_map2(a_plus_b, a_minus_b, bias_mask2, pix_mask, gain):
 
 
 if __name__ == "__main__":
-    import astropy.io.fits as pyfits
+    import libs.fits as pyfits
     a = pyfits.open("../indata/20140525/SDCH_20140525_0016.fits")[0].data
     b = pyfits.open("../indata/20140525/SDCH_20140525_0017.fits")[0].data
 

--- a/recipes/recipe_distort_sky.py
+++ b/recipes/recipe_distort_sky.py
@@ -5,7 +5,7 @@ import numpy as np
 
 
 from libs.path_info import IGRINSPath, IGRINSFiles
-#import astropy.io.fits as pyfits
+#import libs.fits as pyfits
 
 from libs.products import PipelineProducts
 from libs.apertures import Apertures
@@ -426,7 +426,7 @@ def process_distortion_sky_band(utdate, refdate, band, obsids, config):
             msk = order_map == o
             slitoffset_map[msk] = p2_dict[o](xl[msk], slitpos_map[msk])
 
-        import astropy.io.fits as pyfits
+        import libs.fits as pyfits
         #fn = sky_path.get_secondary_path("slitoffset_map.fits")
         #pyfits.PrimaryHDU(data=slitoffset_map).writeto(fn, clobber=True)
 

--- a/recipes/recipe_extract.py
+++ b/recipes/recipe_extract.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 
 from libs.path_info import IGRINSPath
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 
 from libs.products import PipelineProducts
 

--- a/recipes/recipe_extract_base.py
+++ b/recipes/recipe_extract_base.py
@@ -1,5 +1,5 @@
 import numpy as np
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 import scipy.ndimage as ni
 
 from libs.lazyprop import lazyprop

--- a/recipes/recipe_flat.py
+++ b/recipes/recipe_flat.py
@@ -5,7 +5,7 @@ from libs.process_flat import FlatOff, FlatOn
 
 
 from libs.path_info import IGRINSPath
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 
 from libs.recipe_base import RecipeBase
 

--- a/recipes/recipe_tell_wvsol.py
+++ b/recipes/recipe_tell_wvsol.py
@@ -5,7 +5,7 @@ from numpy.polynomial import chebyshev
 from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.optimize import leastsq
 from functools import partial
-from astropy.io import fits
+import libs.fits as fits
 import libs.readmultispec as multispec
 from astropy import units as u
 from astropy.modeling import models, fitting

--- a/recipes/recipe_thar.py
+++ b/recipes/recipe_thar.py
@@ -3,7 +3,7 @@ import os
 
 
 from libs.path_info import IGRINSPath, IGRINSFiles
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 
 from libs.products import PipelineProducts, PipelineImageBase
 from libs.apertures import Apertures

--- a/recipes/recipe_wvlsol_sky.py
+++ b/recipes/recipe_wvlsol_sky.py
@@ -4,7 +4,7 @@ import numpy as np
 #from libs.process_flat import FlatOff, FlatOn
 
 from libs.path_info import IGRINSPath
-#import astropy.io.fits as pyfits
+#import libs.fits as pyfits
 
 from libs.products import PipelineProducts
 from libs.apertures import Apertures
@@ -160,7 +160,7 @@ class ProcessSkyBand(object):
         # sky_master_fn_ = os.path.splitext(os.path.basename(sky_names[0]))[0]
         # sky_master_fn = igr_path.get_secondary_calib_filename(sky_master_fn_)
 
-        import astropy.io.fits as pyfits
+        import libs.fits as pyfits
         masterhdu = pyfits.open(sky_filenames[0])[0]
 
         igr_storage = extractor.igr_storage
@@ -289,7 +289,7 @@ class ProcessSkyBand(object):
 
         # cards = [pyfits.Card.fromstring(l.strip()) \
         #          for l in open("echell_2dspec.header")]
-        import astropy.io.fits as pyfits
+        import libs.fits as pyfits
         cards = [pyfits.Card.fromstring(l.strip()) \
                  for l in default_header_str]
 

--- a/recipes/recipe_wvlsol_v0.py
+++ b/recipes/recipe_wvlsol_v0.py
@@ -2,7 +2,7 @@ import os
 #import numpy as np
 
 
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 
 from libs.products import PipelineProducts, PipelineImageBase
 #from libs.apertures import Apertures

--- a/utils/check_classI.py
+++ b/utils/check_classI.py
@@ -1,6 +1,6 @@
 import os
 import numpy as np
-import astropy.io.fits as pyfits
+import libs.fits as pyfits
 
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
FITS files typically compress nicely & to save disk space I would like to be able to store my raw IGRINS data in gzip'd form. (I usually do a gzip --best *.fits in my raw data directories.)

When reading in a fits file, ideally igrins-plp should seamlessly read either a gzip'd or non-gzip'd file.

I've a simple fix to enable this behavior that I will submit as a pull request. Basically, I've written a simple wrapper to the fits routines and then replace a bunch of import statements throughout the rest of the code to import my wrapper rather than astropy.io.fits. I think it's self explanatory.

(This is Issue#13 in igrins/plp.)
